### PR TITLE
Add font prefix

### DIFF
--- a/src/cairo-ps-surface-private.h
+++ b/src/cairo-ps-surface-private.h
@@ -101,6 +101,7 @@ typedef struct cairo_ps_surface {
     time_t creation_date;
 
     cairo_scaled_font_subsets_t *font_subsets;
+    cairo_bool_t add_font_prefix;
 
     cairo_list_t document_media;
     cairo_array_t dsc_header_comments;

--- a/src/cairo-ps.h
+++ b/src/cairo-ps.h
@@ -80,6 +80,10 @@ cairo_ps_surface_add_meta_stream (cairo_surface_t     *surface,
                                   void	              *closure);
 
 cairo_public void
+cairo_ps_surface_set_add_font_prefix (cairo_surface_t    *surface,
+                                      cairo_bool_t add_font_refix);
+
+cairo_public void
 cairo_ps_surface_restrict_to_level (cairo_surface_t    *surface,
                                     cairo_ps_level_t    level);
 


### PR DESCRIPTION
Adds the ability to add a hash of the font data before the font name (e.g. `/FontName /LGLLGJ+Arial-BoldMT def`) in emitted ps/eps files.

Can be enabled with `cairo_ps_surface_set_add_font_prefix`.
