### PR TITLE
Fixed recursive surface pattern in ps backend not rendered

### DIFF
--- a/src/cairo-ps-surface-private.h
+++ b/src/cairo-ps-surface-private.h
@@ -122,6 +122,7 @@ typedef struct cairo_ps_surface {
     cairo_hash_table_t *forms;
     int num_forms;
     long total_form_size;
+    int pattern_stack;
 } cairo_ps_surface_t;
 
 #endif /* CAIRO_PS_SURFACE_PRIVATE_H */


### PR DESCRIPTION
Currently the ps backend creates following postscript code for recursive surface pattern:
```ps
/CairoPattern {
q 0 0 131 131 rectclip
  q
/CairoPattern {
q 0 0 171 171 rectclip
[ 171 0 0 171 0 0 ] concat
/CairoData [
<~DATA1~>] def
/CairoDataIndex 0 def
/DeviceGray setcolorspace
<<
  /ImageType 1
  /Width 171
  /Height 171
  /Interpolate false
  /BitsPerComponent 8
  /Decode [ 0 1 ]
  /DataSource { cairo_data_source } /FlateDecode filter
  /ImageMatrix [ 171 0 0 -171 0 171 ]
>>
image
 Q } bind def
<< /PatternType 1
   /PaintType 1
   /TilingType 1
   /XStep 684 /YStep 684
   /BBox [0 0 171 171]
   /PaintProc { pop CairoPattern }
>>
[ 0.766082 0 0 0.766082 0 0 ]
makepattern setpattern
q
0 0 131 131 re W n
[ 131 0 0 131 0 0 ] concat
/CairoData [
<~DATA2~>] def
/CairoDataIndex 0 def
<<
  /ImageType 1
  /Width 171
  /Height 171
  /Interpolate false
  /BitsPerComponent 1
  /Decode [ 1 0 ]
  /DataSource { cairo_data_source } /FlateDecode filter
  /ImageMatrix [ 171 0 0 -171 0 171 ]
>>
imagemask
Q 
  Q
 Q } bind def
<< /PatternType 1
   /PaintType 1
   /TilingType 1
   /XStep 131 /YStep 131
   /BBox [0 0 131 131]
   /PaintProc { pop CairoPattern }
>>
```
The child CairoData and CairoDataIndex will be overwriten by parent CairoData and CairoDataIndex.

I also tested the pdf, svg and png backend they work fine

All test are done via pdftocairo